### PR TITLE
Introduce a revision into the data module

### DIFF
--- a/app.fsx
+++ b/app.fsx
@@ -26,6 +26,7 @@ open Suave.Http.Successful
 #load "code/pages/insert.fs"
 #load "code/pages/snippet.fs"
 open FsSnip
+open FsSnip.Data
 open FsSnip.Utils
 open FsSnip.Pages
 
@@ -61,8 +62,10 @@ DotLiquid.setTemplatesDir (__SOURCE_DIRECTORY__ + "/templates")
 let app =
   choose
     [ path "/" >>= Home.showHome
-      pathWithId "/%s" Snippet.showSnippet
-      pathWithId "/raw/%s" Snippet.showRawSnippet
+      pathScan "/%s/%d" (fun (id, r) -> Snippet.showSnippet id (Revision r))
+      pathWithId "/%s" (fun id -> Snippet.showSnippet id Latest)
+      pathScan "/raw/%s/%d" (fun (id, r) -> Snippet.showRawSnippet id (Revision r))
+      pathWithId "/raw/%s" (fun id -> Snippet.showRawSnippet id Latest)
       path "/pages/insert" >>= Insert.insertSnippet
       browseStaticFiles ]
 

--- a/code/common/data.fs
+++ b/code/common/data.fs
@@ -47,19 +47,21 @@ let readSnippets () =
 
 let mutable snippets, publicSnippets = readSnippets ()
 
-let rec private loadSnippetInternal basePath id revision =
+let private loadSnippetInternal basePath id revision =
   let id' = demangleId id
   match Seq.tryFind (fun s -> s.ID = id') publicSnippets with
   | Some snippetInfo ->
       match revision with
-      | Latest -> loadSnippetInternal basePath id (Revision (snippetInfo.Versions - 1))
+      | Latest -> 
+        let r = match revision with Latest -> snippetInfo.Versions - 1 | Revision r -> r
+        Some (File.ReadAllText (sprintf "%s/%d" basePath r))
       | Revision r -> Some (File.ReadAllText(sprintf "%s/%d" basePath r))
   | None -> None
 
 let loadSnippet id = 
   loadSnippetInternal (sprintf "%s/../../data/formatted/%d" __SOURCE_DIRECTORY__ (demangleId id)) id
 
-let rec loadRawSnippet id =
+let loadRawSnippet id =
   loadSnippetInternal (sprintf "%s/../../data/source/%d" __SOURCE_DIRECTORY__ (demangleId id)) id
 
 let getNextId () = (snippets |> Seq.map (fun s -> s.ID) |> Seq.max) + 1

--- a/templates/page.html
+++ b/templates/page.html
@@ -58,7 +58,7 @@
           <div class="col-sm-4">
             <p>The first version of <a href="http://www.fssnip.net">fssnip.net</a> has been created by
               <a href="https://twitter.com/tomaspetricek">@tomaspetricek</a> back <a href="http://tomasp.net/blog/fssnip-website.aspx/">in 2010</a>.
-              This web site is a new, open-source and contribution-friendly veresion.
+              This web site is a new, open-source and contribution-friendly version.
             </p>
           </div>
           <div class="col-sm-4">

--- a/templates/snippet.html
+++ b/templates/snippet.html
@@ -21,6 +21,13 @@
   {{ model.Html }}
 
   <div class="btn-group" role="group" aria-label="..." id="snip-tools">
+    {% if model.Revision > 0 %}
+	<a class="btn btn-default" href="/{{ model.Details.Id | format_id }}/{{ model.Revision | minus:1 }}">Previous Version</a>
+	{% endif %}
+	{% capture rev %}{{ model.Revision | plus:1 }}{% endcapture %}
+	{% if rev < model.Details.Versions %}
+	<a class="btn btn-default" href="/{{ model.Details.Id | format_id }}/{{ model.Revision | plus:1 }}">Next Version</a>
+	{% endif %}
     <button class="btn btn-default" onclick="alert('not implemented :(');">Copy link</button>
     <button class="btn btn-default" onclick="alert('not implemented :(');">Copy source</button>
     <a class="btn btn-default" href="/raw/{{ model.Details.Id | format_id }}">Raw view</a>


### PR DESCRIPTION
Load the latest revision by default

There's no code to handle invalid revisions, nor Suave.io routes/templates to access previous versions yet, but #5 is at least handled (it should use a better template/nicer error message, but we do handle 'that does not exist' now)
