### PR TITLE
Fix duplicates in two column lists

### DIFF
--- a/templates/list.html
+++ b/templates/list.html
@@ -2,8 +2,8 @@
   <div class="content col-md-6">
     <ul>
       {% for item in items %}
-	    {% capture leftRight %}{% cycle 'left', 'right' %}{% endcapture %}
-        {% if leftRight == 'left' %}
+        {% assign mod = forloop.index0 | modulo:2 %}
+        {% if mod == 0 %}
            {% include "item.html" item:item %}
         {% endif %}
       {% endfor %}
@@ -12,8 +12,8 @@
   <div class="content col-md-6">
     <ul>
       {% for item in items %}
-	    {% capture leftRight %}{% cycle 'left', 'right' %}{% endcapture %}
-        {% if leftRight == 'right' %}
+        {% assign mod = forloop.index0 | modulo:2 %}
+        {% if mod == 1 %}
            {% include "item.html" item:item %}
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
Remove the cycle hack after discovering the modulo filter - this is what the template should've used from the start.

Seems to fix #20 for me, judging by

```
http://localhost:8083/tags/source
http://localhost:8083/tags/fuzzy
http://localhost:8083/tags/wpf
```
