### PR TITLE
robots.txt to fix #52

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /pages/Update/
+Disallow: /*/update
+Disallow: /embed/
+Host: fssnip.net


### PR DESCRIPTION
Allow only indexing of the home page and snippets (like "fssnip.net/ac")
Naked domain as the main mirror (over www prefix).
Tested here: https://webmaster.yandex.com/robots.xml with the following results:
        http://fssnip.net/  allowed -  
    http://fssnip.net/18    allowed -  
    http://fssnip.net/embed/raw/fJ  blocked by rule /embed/ -  
    http://fssnip.net/18/update blocked by rule /_/update_  -  
    http://fssnip.net/pages/Update/18   blocked by rule /pages/Update/  -  
    http://fssnip.net/authors/Tuomas+Hietanen   allowed -
