### PR TITLE
Fix for #77. And #66.

### DIFF
--- a/code/common/data.fs
+++ b/code/common/data.fs
@@ -38,7 +38,7 @@ let private readSnippet (s:Index.Snippet) =
   { ID = s.Id; Title = s.Title; Comment = s.Comment; Author = s.Author;
     Link = s.Link; Date = s.Date; Likes = s.Likes; Private = s.IsPrivate;
     Passcode = s.Passcode; References = s.References; Source = s.Source;
-    Versions = s.Versions; Tags = s.DisplayTags }
+    Versions = s.Versions; Tags = (s.DisplayTags |> Array.map(fun t -> t.ToLowerInvariant())) }
 
 let private saveSnippet (s:Snippet) =
   Index.Snippet

--- a/code/common/filters.fs
+++ b/code/common/filters.fs
@@ -10,6 +10,9 @@ open System
 let formatId (id:int) =
   mangleId id
 
+let cleanTitle (title:string) = 
+  generateCleanTitle title
+
 let urlEncode (url:string) =
   System.Web.HttpUtility.UrlEncode(url)
 

--- a/code/common/utils.fs
+++ b/code/common/utils.fs
@@ -57,6 +57,13 @@ let tryGetHashedPasscode (p:string) =
 let delay (f:unit -> WebPart) ctx = 
   async { return! f () ctx }
 
+/// Cleanup url for title: "concurrent memoization" -> concurrent-memoization
+let generateCleanTitle title = 
+    System.Web.HttpUtility.UrlEncode(
+        System.Text.RegularExpressions.Regex.Replace(
+            System.Text.RegularExpressions.Regex.Replace(title, "[^a-zA-Z0-9 ]", ""), 
+            " +", "-"))
+
 module Seq =
   /// Take the number of elements specified by `take`, then shuffle the
   /// rest of the items and then take just the `top` number of elements

--- a/code/pages/insert.fs
+++ b/code/pages/insert.fs
@@ -63,7 +63,7 @@ let insertSnippet ctx = async {
             Author = author; Link = link; Date = System.DateTime.UtcNow;
             Likes = 0; Private = form.Hidden; Passcode = Utils.sha1Hash (defaultArg form.Passcode "");
             References = nugetReferences; Source = ""; Versions = 1;
-            Tags = tags }
+            Tags = tags |> Array.map(fun t -> t.ToLowerInvariant()) }
           form.Code html
         return! Redirection.FOUND ("/" + Utils.mangleId id) ctx
 

--- a/code/pages/search.fs
+++ b/code/pages/search.fs
@@ -20,9 +20,11 @@ type Results =
 // Loading search results
 // -------------------------------------------------------------------------------------------------
 
-let getResults (query) =
+let getResults (query:string) =
   publicSnippets
-  |> Seq.filter (fun s -> [ s.Title ; s.Comment ] |> Seq.exists (fun x -> x.Contains(query)))
+  |> Seq.filter (fun s -> 
+    [ s.Title ; s.Comment; s.Title.ToLowerInvariant() ; s.Comment.ToLowerInvariant() ]
+    |> Seq.exists (fun x -> x.Contains(query) ))
 
 let showResults (query) = delay (fun () -> 
   let decodedQuery = FsSnip.Filters.urlDecode query

--- a/code/pages/snippet.fs
+++ b/code/pages/snippet.fs
@@ -49,6 +49,7 @@ let webPart =
   choose 
     [ pathScan "/%s/%d" (fun (id, r) -> showSnippet id (Revision r))
       pathWithId "/%s" (fun id -> showSnippet id Latest)
+      pathScan "/%s/title/%s" (fun (id, title) -> showSnippet id Latest)
       pathScan "/raw/%s/%d" (fun (id, r) -> showRawSnippet id (Revision r))
       pathWithId "/raw/%s" (fun id -> showRawSnippet id Latest) ]
   

--- a/templates/item.html
+++ b/templates/item.html
@@ -1,5 +1,5 @@
 <li>
-  <h3><a href="/{{ item.ID | format_id }}">{{ item.Title }}</a></h3>
+  <h3><a href="/{{ item.ID | format_id }}/title/{{ item.Title | clean_title }}">{{ item.Title }}</a></h3>
   <p>{{ item.Comment }}</p>
   <span class="likeCount">{{ item.Likes }}</span> people like this<br />
   <a href="javascript:;" class="likeLink" data-snippetid="{{ item.ID | format_id }}">Like the snippet!</a>


### PR DESCRIPTION
1) #77: Search fixes. Now you can search with lower case and still find the correct results.
2) #77: tags-page shows case-insensitive results, so Async and async are merged to one.
3) #66: You can call snippet with: http://fssnip.net/c4/title/whatever-clean-title
Utils.fs has also function generateCleanTitle
