### PR TITLE
Update rss link in page.html

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -15,7 +15,7 @@
     <link href="/favicon.ico" rel="icon" />
 
     <!-- Rss Feed -->
-    <link rel="alternate" type="application/rss+xml" title="Recent F# snippets" href="/rss" />
+    <link rel="alternate" type="application/rss+xml" title="Recent F# snippets" href="/rss/" />
 </head>
 
 <body>


### PR DESCRIPTION
The rss link was returning a 404 for where it was pointing: https://www.fssnip.net/rss 

Changing it to point to https://www.fssnip.net/rss/ fixed it.